### PR TITLE
Implement User class, prepare Track for Firestore use, and update TrackMetadata behaviour

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,11 +56,6 @@ dependencies {
     implementation platform(libs.firebase.bom)
     implementation libs.firebase.firestore
 
-    implementation(libs.google.api.client) {
-        exclude group: "org.apache.httpcomponents"
-        exclude group: "com.google.auth", module: "google-auth-library-credentials"
-    }
-
     implementation(libs.google.api.services.youtube) {
         exclude group: "org.apache.httpcomponents"
         exclude group: "com.google.auth"

--- a/app/src/main/java/com/jvn/musilog/data/Track.java
+++ b/app/src/main/java/com/jvn/musilog/data/Track.java
@@ -93,6 +93,33 @@ public class Track {
   }
 
   /**
+   * Returns the hash code for this {@link Track}, to be used in equality comparisons. Tracks with
+   * the same {@link Track#source source} and {@link Track#sourceId sourceId} will have the same
+   * hash code.
+   *
+   * @return The {@link Track}'s hash code
+   */
+  @Override
+  public int hashCode() {
+    return (source.toString() + ":" + sourceId).hashCode();
+  }
+
+  /**
+   * Checks if two {@link Track}s are equal to each other.
+   *
+   * @param that The {@link Track} to compare
+   * @return A {@code boolean} indicating if the two objects are equal
+   */
+  @Override
+  public boolean equals(Object that) {
+    if ((that == null) || (that.getClass() != Track.class)) {
+      return false;
+    }
+
+    return that.hashCode() == hashCode();
+  }
+
+  /**
    * @return The {@link MusicSource} for this music track
    */
   @PropertyName(SOURCE_FIELD)

--- a/app/src/main/java/com/jvn/musilog/data/Track.java
+++ b/app/src/main/java/com/jvn/musilog/data/Track.java
@@ -1,14 +1,22 @@
 package com.jvn.musilog.data;
 
+import com.google.firebase.firestore.PropertyName;
+
 import java.util.regex.*;
 
 /**
- * Class for music track data.
+ * Class for music track data. Meant to be used as a custom object in Firestore.
  *
  * @author Poleon Banouvong
  * @since 2024-03-17
  */
 public class Track {
+  /** The corresponding Firestore document field name for the {@link Track#source} member. */
+  private static final String SOURCE_FIELD = "source";
+
+  /** The corresponding Firestore document field name for the {@link Track#sourceId} member. */
+  private static final String SOURCE_ID_FIELD = "sourceId";
+
   /**
    * Regex pattern for a YouTube video ID. Google doesn't specify the format of these IDs, but <a
    * href="https://webapps.stackexchange.com/questions/54443/format-for-id-of-youtube-video#answer-101153">reverse-engineering</a>
@@ -39,17 +47,18 @@ public class Track {
   /** The ID of the music track, relative to its source. */
   private String sourceId;
 
-  /** The metadata of the music track. */
-  private TrackMetadata metadata;
+  /** Default constructor. Required to be public to be used as a custom object in Firestore. */
+  public Track() {}
 
-  /** Private default constructor. Use {@link Track#fromUrl} instead. */
-  private Track() {}
-
-  /** Private qualified constructor. Use {@link Track#fromUrl} instead. */
-  private Track(MusicSource source, String sourceId, TrackMetadata metadata) {
+  /**
+   * Qualified {@link Track} constructor.
+   *
+   * @param source The {@link MusicSource} the track is coming from
+   * @param sourceId The source ID of the track
+   */
+  public Track(MusicSource source, String sourceId) {
     this.source = source;
     this.sourceId = sourceId;
-    this.metadata = metadata;
   }
 
   /**
@@ -80,13 +89,13 @@ public class Track {
       sourceId = "";
     }
 
-    TrackMetadata metadata = TrackMetadata.fromMusicSource(source, sourceId);
-    return new Track(source, sourceId, metadata);
+    return new Track(source, sourceId);
   }
 
   /**
    * @return The {@link MusicSource} for this music track
    */
+  @PropertyName(SOURCE_FIELD)
   public MusicSource getSource() {
     return source;
   }
@@ -94,14 +103,8 @@ public class Track {
   /**
    * @return The source ID, relative to the music source, for this music track
    */
+  @PropertyName(SOURCE_ID_FIELD)
   public String getSourceId() {
     return sourceId;
-  }
-
-  /**
-   * @return The metadata for this music track
-   */
-  public TrackMetadata getMetadata() {
-    return metadata;
   }
 }

--- a/app/src/main/java/com/jvn/musilog/data/TrackMetadata.java
+++ b/app/src/main/java/com/jvn/musilog/data/TrackMetadata.java
@@ -30,23 +30,28 @@ import se.michaelthelin.spotify.requests.data.tracks.GetTrackRequest;
  */
 public class TrackMetadata {
   /** The title of the music track. */
-  private final String title;
+  private String title;
 
   /** The list of artists for the music track. */
-  private final String artistLine;
+  private String artistLine;
 
   /** The cover art URL for the music track. */
-  private final String coverArtUrl;
+  private String coverArtUrl;
 
-  /** Private default constructor. Use {@link TrackMetadata#fromMusicSource} instead. */
-  private TrackMetadata() {
-    this.title = "";
-    this.artistLine = "";
-    this.coverArtUrl = "";
-  }
+  /**
+   * Default constructor. Use {@link TrackMetadata#TrackMetadata(String, String, String)} or {@link
+   * TrackMetadata#fromMusicSource} instead.
+   */
+  private TrackMetadata() {}
 
-  /** Private qualified constructor. Use {@link TrackMetadata#fromMusicSource} instead. */
-  private TrackMetadata(String title, String artistLine, String coverArtUrl) {
+  /**
+   * Qualified constructor.
+   *
+   * @param title The title of the music track
+   * @param artistLine The list of artists for the music track
+   * @param coverArtUrl A URL to a covert art image for the music track
+   */
+  public TrackMetadata(String title, String artistLine, String coverArtUrl) {
     this.title = title;
     this.artistLine = artistLine;
     this.coverArtUrl = coverArtUrl;
@@ -54,10 +59,10 @@ public class TrackMetadata {
 
   /**
    * Creates {@link TrackMetadata} from a Spotify music track. If there's a problem retrieving the
-   * metadata, a {@link TrackMetadata} with no information will be returned.
+   * metadata, {@code null} will be returned.
    *
    * @param sourceId The Spotify track ID
-   * @return A {@link TrackMetadata} describing the music track
+   * @return A {@link TrackMetadata} describing the music track, which may be {@code null}
    */
   private static TrackMetadata fromSpotify(String sourceId) {
     /*
@@ -67,7 +72,7 @@ public class TrackMetadata {
     SpotifyApi api = ApiProvider.getSpotifyApi();
 
     if (api == null) {
-      return new TrackMetadata();
+      return null;
     }
 
     try {
@@ -92,17 +97,17 @@ public class TrackMetadata {
       return new TrackMetadata(
           trackResponse.getName(), artistLine.toString(), albumCoverArtUrls[0].getUrl());
     } catch (IOException | SpotifyWebApiException | ParseException except) {
-      return new TrackMetadata();
+      return null;
     }
   }
 
   /**
    * Creates {@link TrackMetadata} from a YouTube music track. Note that this method doesn't verify
    * that the provided video ID is in fact for a music track. If there's a problem retrieving the
-   * metadata, a {@link TrackMetadata} with no information will be returned.
+   * metadata, {@code null} will be returned.
    *
    * @param sourceId The YouTube track ID
-   * @return A {@link TrackMetadata} describing the music track
+   * @return A {@link TrackMetadata} describing the music track, which may be {@code null}
    */
   private static TrackMetadata fromYouTube(String sourceId) {
     /*
@@ -112,7 +117,7 @@ public class TrackMetadata {
     YouTube api = ApiProvider.getYoutubeApi();
 
     if (api == null) {
-      return new TrackMetadata();
+      return null;
     }
 
     List<String> videoParts = List.of("snippet");
@@ -128,7 +133,7 @@ public class TrackMetadata {
       List<Video> videos = videosResponse.getItems();
 
       if (videos.isEmpty()) {
-        return new TrackMetadata();
+        return null;
       } else {
         Video video = videos.get(0);
         VideoSnippet videoSnippet = video.getSnippet();
@@ -141,18 +146,18 @@ public class TrackMetadata {
       }
     } catch (IOException
         | NullPointerException except) { // many of the API calls can return null values
-      return new TrackMetadata();
+      return null;
     }
   }
 
   /**
    * Creates {@link TrackMetadata} from a music source and ID. If the music source is {@link
-   * MusicSource#Unknown}, or there's a problem retrieving the metadata, a {@link TrackMetadata}
-   * with no information will be returned.
+   * MusicSource#Unknown Unknown}, or there's a problem retrieving the metadata, {@code null} will
+   * be returned.
    *
    * @param source The {@link MusicSource} to get the metadata from
    * @param sourceId The music track ID
-   * @return A {@link TrackMetadata} describing the music track
+   * @return A {@link TrackMetadata} describing the music track, which may be {@code null}
    */
   public static TrackMetadata fromMusicSource(MusicSource source, String sourceId) {
     switch (source) {
@@ -161,7 +166,7 @@ public class TrackMetadata {
       case YouTube:
         return fromYouTube(sourceId);
       default:
-        return new TrackMetadata();
+        return null;
     }
   }
 

--- a/app/src/main/java/com/jvn/musilog/data/User.java
+++ b/app/src/main/java/com/jvn/musilog/data/User.java
@@ -90,7 +90,7 @@ public class User {
 
   /**
    * @return The user's playlist, which will not contain duplicate tracks (tracks with the same
-   *     source and source ID) or {@code null} tracks
+   *     source and source ID) or {@code null} tracks, and which may be {@code null}
    */
   @PropertyName(PLAYLIST_FIELD)
   public ArrayList<Track> getPlaylist() {

--- a/app/src/main/java/com/jvn/musilog/data/User.java
+++ b/app/src/main/java/com/jvn/musilog/data/User.java
@@ -1,0 +1,127 @@
+package com.jvn.musilog.data;
+
+import com.google.firebase.firestore.PropertyName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.function.Predicate;
+
+/**
+ * Class for user information. Meant to be used as a custom object in Firestore.
+ *
+ * @author Poleon Banouvong
+ * @since 2024-03-29
+ */
+public class User {
+  /** The corresponding Firestore document field name for the {@link User#playlist} variable. */
+  private static final String PLAYLIST_FIELD = "playlist";
+
+  /**
+   * The corresponding Firestore document field name for the {@link User#playlistDescription}
+   * variable.
+   */
+  private static final String PLAYLIST_DESCRIPTION_FIELD = "playlistDescription";
+
+  /**
+   * The corresponding Firestore document field name for the {@link User#averageRating} variable.
+   */
+  private static final String AVERAGE_RATING_FIELD = "averageRating";
+
+  /** The corresponding Firestore document field name for the {@link User#numRatings} variable. */
+  private static final String NUM_RATINGS_FIELD = "numRatings";
+
+  /**
+   * The list of music tracks the user has added to their playlist. This list must not contain any
+   * duplicate tracks, tracks whose sources are {@link MusicSource#Unknown Unknown}, or {@code null}
+   * tracks.<br>
+   * <br>
+   * The data type is a {@link java.util.List List} because collections, such as {@link
+   * LinkedHashSet}, are not serialisable by Firestore.
+   */
+  private ArrayList<Track> playlist;
+
+  /** The description of the user's playlist. */
+  private String playlistDescription;
+
+  /** The average rating of the user's playlist. */
+  private Float averageRating;
+
+  /** The number of ratings on the user's playlist. */
+  private Integer numRatings;
+
+  /** Default constructor. Required to be public to be used as a custom object in Firestore. */
+  public User() {}
+
+  /**
+   * Qualified constructor. If the playlist contains either {@code null} tracks or tracks whose
+   * source is {@link MusicSource#Unknown Unknown}, those tracks will be removed. Additionally, if
+   * the playlist contains duplicate tracks, all but one of the duplicate tracks will be removed.
+   *
+   * @param playlist The list of {@link Track}s in the user's playlist
+   * @param playlistDescription The description of the user's playlist
+   * @param averageRating The average rating of the user's playlist
+   * @param numRatings The number of ratings on the user's playlist
+   */
+  public User(
+      ArrayList<Track> playlist,
+      String playlistDescription,
+      Float averageRating,
+      Integer numRatings) {
+    if (playlist != null) {
+      // converting the list to a LinkedHashSet removes duplicate tracks
+      LinkedHashSet<Track> checkedPlaylist = new LinkedHashSet<Track>(playlist);
+
+      // remove tracks that have an Unknown source or are null
+      checkedPlaylist.removeIf(
+          new Predicate<Track>() {
+            @Override
+            public boolean test(Track track) {
+              return (track == null) || (track.getSource() == MusicSource.Unknown);
+            }
+          });
+
+      this.playlist = new ArrayList<Track>(checkedPlaylist);
+    }
+
+    this.playlistDescription = playlistDescription;
+    this.averageRating = averageRating;
+    this.numRatings = numRatings;
+  }
+
+  /**
+   * @return The user's playlist, which will not contain duplicate tracks (tracks with the same
+   *     source and source ID) or {@code null} tracks
+   */
+  @PropertyName(PLAYLIST_FIELD)
+  public ArrayList<Track> getPlaylist() {
+    if (playlist == null) {
+      return null;
+    }
+
+    return new ArrayList<Track>(playlist);
+  }
+
+  /**
+   * @return The user's playlist description.
+   */
+  @PropertyName(PLAYLIST_DESCRIPTION_FIELD)
+  public String getPlaylistDescription() {
+    return playlistDescription;
+  }
+
+  /**
+   * @return The average rating of the user's playlist.
+   */
+  @PropertyName(AVERAGE_RATING_FIELD)
+  public Float getAveragePlaylistRating() {
+    return averageRating;
+  }
+
+  /**
+   * @return the number of ratings on the user's playlist.
+   */
+  @PropertyName(NUM_RATINGS_FIELD)
+  public Integer getNumPlaylistRatings() {
+    return numRatings;
+  }
+}

--- a/app/src/test/java/com/jvn/musilog/data/TrackMetadataTest.java
+++ b/app/src/test/java/com/jvn/musilog/data/TrackMetadataTest.java
@@ -11,6 +11,16 @@ import org.junit.Test;
  * @since 2024-03-16
  */
 public class TrackMetadataTest {
+  /** Tests that the qualified constructor works as intended. */
+  @Test
+  public void testQualifiedConstructor() {
+    TrackMetadata metadata = new TrackMetadata("Title", "Artists", "https://www.example.org/");
+
+    assertEquals("Title", metadata.getTitle());
+    assertEquals("Artists", metadata.getArtistLine());
+    assertEquals("https://www.example.org/", metadata.getCoverArtUrl());
+  }
+
   /**
    * Tests that metadata can be retrieved for a Spotify music track. This test depends on external
    * factors such as network and Spotify service availability, and assumes that all such factors do
@@ -22,23 +32,15 @@ public class TrackMetadataTest {
     TrackMetadata spotifyMetadata =
         TrackMetadata.fromMusicSource(MusicSource.Spotify, "2tmuRm2ROZ0vHEhutI2Hlp");
 
+    TrackMetadata spotifyMetadataBadId =
+        TrackMetadata.fromMusicSource(MusicSource.Spotify, "badId");
+
+    assertNotNull(spotifyMetadata);
+    assertNull(spotifyMetadataBadId);
+
     assertEquals("Mane Mane Psychotropic", spotifyMetadata.getTitle());
     assertEquals("Kairikibear", spotifyMetadata.getArtistLine());
     assertNotEquals("", spotifyMetadata.getCoverArtUrl());
-  }
-
-  /**
-   * Tests that metadata cannot be retrieved for a bad Spotify music track ID. This test depends on
-   * external factors such as network and Spotify service availability, and assumes that all such
-   * factors do not fail.
-   */
-  @Test
-  public void testFromSpotifyBadId() {
-    TrackMetadata spotifyMetadata = TrackMetadata.fromMusicSource(MusicSource.Spotify, "badId");
-
-    assertEquals("", spotifyMetadata.getTitle());
-    assertEquals("", spotifyMetadata.getArtistLine());
-    assertEquals("", spotifyMetadata.getCoverArtUrl());
   }
 
   /**
@@ -52,6 +54,12 @@ public class TrackMetadataTest {
     TrackMetadata youTubeMetadata =
         TrackMetadata.fromMusicSource(MusicSource.YouTube, "Dun11cIEo9s");
 
+    TrackMetadata youTubeMetadataBadId =
+        TrackMetadata.fromMusicSource(MusicSource.YouTube, "badId");
+
+    assertNotNull(youTubeMetadata);
+    assertNull(youTubeMetadataBadId);
+
     assertEquals(
         "Neru - potatoになっていく (Becoming Potatoes) feat. Kagamine Rin & Kagamine Len",
         youTubeMetadata.getTitle());
@@ -60,30 +68,10 @@ public class TrackMetadataTest {
     assertNotEquals("", youTubeMetadata.getCoverArtUrl());
   }
 
-  /**
-   * Tests that metadata cannot be retrieved for a bad YouTube music track ID. This test depends on
-   * external factors such as network and YouTube service availability, and assumes that all such
-   * factors do not fail.
-   */
-  @Test
-  public void testFromYouTubeBadId() {
-    TrackMetadata youTubeMetadata = TrackMetadata.fromMusicSource(MusicSource.YouTube, "badId");
-
-    assertEquals("", youTubeMetadata.getTitle());
-    assertEquals("", youTubeMetadata.getArtistLine());
-    assertEquals("", youTubeMetadata.getCoverArtUrl());
-  }
-
-  /**
-   * Tests that attempting to retrieve metadata from an unknown source will return an empty {@link
-   * TrackMetadata}.
-   */
+  /** Tests that attempting to retrieve metadata from an unknown source will return {@code null}. */
   @Test
   public void testFromUnknown() {
     TrackMetadata unknownMetadata = TrackMetadata.fromMusicSource(MusicSource.Unknown, "");
-
-    assertEquals("", unknownMetadata.getTitle());
-    assertEquals("", unknownMetadata.getArtistLine());
-    assertEquals("", unknownMetadata.getCoverArtUrl());
+    assertNull(unknownMetadata);
   }
 }

--- a/app/src/test/java/com/jvn/musilog/data/TrackTest.java
+++ b/app/src/test/java/com/jvn/musilog/data/TrackTest.java
@@ -46,7 +46,6 @@ public class TrackTest {
 
       assertEquals(MusicSource.Spotify, track.getSource());
       assertEquals(expectedIds[i], track.getSourceId());
-      assertNotEquals(null, track.getMetadata());
     }
   }
 
@@ -76,7 +75,6 @@ public class TrackTest {
 
       assertEquals(MusicSource.YouTube, track.getSource());
       assertEquals(expectedIds[i], track.getSourceId());
-      assertNotEquals(null, track.getMetadata());
     }
   }
 
@@ -106,7 +104,6 @@ public class TrackTest {
 
       assertEquals(MusicSource.YouTube, track.getSource());
       assertEquals(expectedIds[i], track.getSourceId());
-      assertNotEquals(null, track.getMetadata());
     }
   }
 
@@ -140,7 +137,6 @@ public class TrackTest {
 
       assertEquals(MusicSource.Unknown, track.getSource());
       assertEquals("", track.getSourceId());
-      assertNotEquals(null, track.getMetadata());
     }
   }
 }

--- a/app/src/test/java/com/jvn/musilog/data/TrackTest.java
+++ b/app/src/test/java/com/jvn/musilog/data/TrackTest.java
@@ -11,6 +11,26 @@ import org.junit.Test;
  * @since 2024-03-17
  */
 public class TrackTest {
+  /** Tests that {@link Track}s with the same data are equal, and that {@link Track}s that don't have the same data are not equal. */
+  @Test
+  public void testEquality() {
+    // same sources, same IDs
+    Track track1 = new Track(MusicSource.Unknown, "ABCD");
+    Track equalTrack1 = new Track(MusicSource.Unknown, "ABCD");
+
+    // different sources, same IDs
+    Track track2 = new Track(MusicSource.Spotify, "ABCD");
+    Track unequalTrack2 = new Track(MusicSource.YouTube, "ABCD");
+
+    // same sources, different IDs
+    Track track3 = new Track(MusicSource.YouTube, "ABCD");
+    Track unequalTrack3 = new Track(MusicSource.YouTube, "EFGH");
+
+    assertEquals(track1, equalTrack1);
+    assertNotEquals(track2, unequalTrack2);
+    assertNotEquals(track3, unequalTrack3);
+  }
+
   /** Tests that {@link Track}s for Spotify URLs are correctly generated. */
   @Test
   public void testFromSpotifyUrl() {

--- a/app/src/test/java/com/jvn/musilog/data/UserTest.java
+++ b/app/src/test/java/com/jvn/musilog/data/UserTest.java
@@ -102,6 +102,16 @@ public class UserTest {
     assertEquals(track3, returnedPlaylist.get(2));
   }
 
+  /** Tests that the playlist is returned properly. */
+  @Test
+  public void testPlaylist() {
+    User newUser1 = new User(null, null, null, null);
+    User newUser2 = new User(new ArrayList<Track>(), null, null, null);
+
+    assertNull(newUser1.getPlaylist());
+    assertNotNull(newUser2.getPlaylist());
+  }
+
   /** Tests that the playlist description is returned properly. */
   @Test
   public void testPlaylistDescription() {

--- a/app/src/test/java/com/jvn/musilog/data/UserTest.java
+++ b/app/src/test/java/com/jvn/musilog/data/UserTest.java
@@ -1,0 +1,125 @@
+package com.jvn.musilog.data;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+/**
+ * Unit tests for the {@link User} class.
+ *
+ * @author Poleon Banouvong
+ * @since 2024-03-29
+ */
+public class UserTest {
+  /** Test {@link Track} with a {@link MusicSource#Spotify Spotify} source. */
+  private final Track spotifyTrack = new Track(MusicSource.Spotify, "abcd");
+
+  /** Test {@link Track} with a {@link MusicSource#YouTube YouTube} source. */
+  private final Track youTubeTrack = new Track(MusicSource.YouTube, "efgh");
+
+  /** Test {@link Track} with an {@link MusicSource#Unknown Unknown} source. */
+  private final Track unknownTrack = new Track(MusicSource.Unknown, "ijkl");
+
+  /** Tests that the qualified {@link User} constructor works as intended. */
+  @Test
+  public void testQualifiedConstructor() {
+    ArrayList<Track> playlist = new ArrayList<>();
+    playlist.add(spotifyTrack);
+    playlist.add(youTubeTrack);
+
+    User newUser = new User(playlist, "This is a playlist.", (float) 0, 0);
+
+    assertEquals(2, newUser.getPlaylist().size());
+    assertEquals("This is a playlist.", newUser.getPlaylistDescription());
+    assertEquals(0, (float) newUser.getAveragePlaylistRating(), 0);
+    assertEquals(0, (int) newUser.getNumPlaylistRatings());
+  }
+
+  /**
+   * Tests that playlists cannot contain tracks whose source is {@link MusicSource#Unknown Unknown}.
+   */
+  @Test
+  public void testPlaylistNoUnknowns() {
+    Track track4 = new Track(MusicSource.Unknown, "mnop");
+
+    ArrayList<Track> playlist = new ArrayList<Track>();
+    playlist.add(spotifyTrack);
+    playlist.add(unknownTrack);
+    playlist.add(youTubeTrack);
+    playlist.add(track4);
+
+    User newUser = new User(playlist, null, null, null);
+    assertEquals(2, newUser.getPlaylist().size());
+  }
+
+  /**
+   * Tests that playlists cannot contain duplicate tracks (tracks with the same source and source
+   * ID).
+   */
+  @Test
+  public void testPlaylistNoDuplicates() {
+    // test with the same Track object
+    ArrayList<Track> playlist1 = new ArrayList<Track>();
+    playlist1.add(spotifyTrack);
+    playlist1.add(spotifyTrack);
+    playlist1.add(spotifyTrack);
+    playlist1.add(spotifyTrack);
+
+    // test with different Track objects with the same data
+    ArrayList<Track> playlist2 = new ArrayList<Track>();
+    playlist2.add(new Track(MusicSource.Spotify, "abcd"));
+    playlist2.add(new Track(MusicSource.Spotify, "abcd"));
+    playlist2.add(new Track(MusicSource.Spotify, "abcd"));
+    playlist2.add(new Track(MusicSource.Spotify, "abcd"));
+
+    User newUser1 = new User(playlist1, null, null, null);
+    User newUser2 = new User(playlist2, null, null, null);
+
+    assertEquals(1, newUser1.getPlaylist().size());
+    assertEquals(1, newUser2.getPlaylist().size());
+  }
+
+  /**
+   * Tests that the playlist preserves ordering, since if may be modified when passed to the
+   * constructor.
+   */
+  @Test
+  public void testPlaylistOrdering() {
+    Track track3 = new Track(MusicSource.Spotify, "mnop");
+
+    ArrayList<Track> playlist = new ArrayList<Track>();
+    playlist.add(spotifyTrack);
+    playlist.add(youTubeTrack);
+    playlist.add(track3);
+
+    User newUser = new User(playlist, null, null, null);
+    ArrayList<Track> returnedPlaylist = newUser.getPlaylist();
+
+    assertEquals(spotifyTrack, returnedPlaylist.get(0));
+    assertEquals(youTubeTrack, returnedPlaylist.get(1));
+    assertEquals(track3, returnedPlaylist.get(2));
+  }
+
+  /** Tests that the playlist description is returned properly. */
+  @Test
+  public void testPlaylistDescription() {
+    User newUser = new User(null, "This is a null playlist.", null, null);
+    assertEquals("This is a null playlist.", newUser.getPlaylistDescription());
+  }
+
+  /** Tests that the average rating is returned properly. */
+  @Test
+  public void testAverageRating() {
+    User newUser = new User(null, null, (float) 1.24, null);
+    assertEquals(1.24, newUser.getAveragePlaylistRating(), 0.01);
+  }
+
+  /** Tests that the number of ratings is returned properly. */
+  @Test
+  public void testNumRatings() {
+    User newUser = new User(null, null, null, 250);
+    assertEquals(250, (int) newUser.getNumPlaylistRatings());
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ constraintlayout = "2.1.4"
 googleServices = "4.4.1"
 secrets = "2.0.1"
 firebaseBom = "32.7.4"
-googleApiClient = "2.4.0"
 googleApiServicesYouTube = "v3-rev20240310-2.0.0"
 spotifyWebApiJava = "8.3.6"
 
@@ -24,7 +23,6 @@ activity = { group = "androidx.activity", name = "activity", version.ref = "acti
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom"  }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
-google-api-client = { module = "com.google.api-client:google-api-client", version.ref = "googleApiClient" }
 google-api-services-youtube = { module = "com.google.apis:google-api-services-youtube", version.ref = "googleApiServicesYouTube" }
 spotify-web-api-java = { module = "se.michaelthelin.spotify:spotify-web-api-java", version.ref = "spotifyWebApiJava" }
 


### PR DESCRIPTION
This pull request adds the User class, prepares the Track class for Firestore use, and updates the TrackMetadata class to return nulls instead of TrackMetadatas with dummy data.

It also resolves the issue of Firebase being unable to connect to the service.

- Closes #70 
- Closes #71 
- Closes #72